### PR TITLE
Added dev scripts

### DIFF
--- a/icebergserver/package.json
+++ b/icebergserver/package.json
@@ -4,8 +4,11 @@
   "description": "Backend for Iceberg app",
   "main": "app.js",
   "scripts": {
-    "dev": "nodemon app.js",
-    "start": "node app.js"
+    "client-install": "npm install --prefix ../icebergwebapp",
+    "start": "node app.js",
+    "server": "nodemon app.js",
+    "client": "npm start --prefix ../icebergwebapp",
+    "dev": "concurrently \"npm run server\" \"npm run client\""
   },
   "author": "JapanPanda",
   "license": "ISC",
@@ -13,6 +16,7 @@
     "bcrypt": "^5.0.0",
     "body-parser": "^1.19.0",
     "celebrate": "^12.1.1",
+    "concurrently": "^5.2.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
@@ -24,6 +28,7 @@
     "mime-types": "^2.1.27",
     "mongodb": "^3.5.9",
     "mongoose": "^5.9.21",
+    "nodemon": "^2.0.4",
     "passport": "^0.4.1",
     "passport-local": "^1.0.0",
     "typedi": "^0.8.0",


### PR DESCRIPTION
Instead of going into both the webapps and server folder and running npm, go into server folder and run "npm run dev". This should run both instances of nodemon onto the server and the front end.

Commands (within server folder) :
both : npm run dev
server : npm run server
client : npm run client